### PR TITLE
Add aggregation field to stock_report query

### DIFF
--- a/addons/stock/report/report_stock.py
+++ b/addons/stock/report/report_stock.py
@@ -52,7 +52,7 @@ class report_stock_lines_date(osv.osv):
                         inner join stock_inventory s on (l.inventory_id=s.id and s.state = 'done')
                     ) on (p.id=l.product_id)
                     left join stock_move m on (m.product_id=p.id and m.state = 'done')
-                group by p.id
+                group by p.id, p.active
             )""")
 
 


### PR DESCRIPTION
The `group by` clause lacked a field.
Aggregation fields can be deduced by PostgreSQL >= 9.1 but not in earlier versions.
The change fixes the report for earlier PostgreSQL versions (tested in PostgreSQL 8.4).
